### PR TITLE
Add compatibility for Symfony 5 Data Collector

### DIFF
--- a/src/DataCollector/ElasticaDataCollector.php
+++ b/src/DataCollector/ElasticaDataCollector.php
@@ -30,7 +30,7 @@ class ElasticaDataCollector extends DataCollector
         $this->logger = $logger;
     }
 
-    public function collect(Request $request, Response $response, \Exception $exception = null)
+    public function collect(Request $request, Response $response, ?Throwable $exception = NULL)
     {
         $this->data['nb_queries'] = $this->logger->getNbQueries();
         $this->data['queries'] = $this->logger->getQueries();


### PR DESCRIPTION
Otherwise, I'm seeing this error

Compile Error: Declaration of FOS\ElasticaBundle\DataCollector\ElasticaDataCollector::collect(Symfony\Component\HttpFoundation\Request $request, Symfony\Component\HttpFoundation\Response $response, ?Exception $exception = NULL) must be compatible with Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface::collect(Symfony\Component\HttpFoundation\Request $request, Symfony\Component\HttpFoundation\Response $response, ?Throwable $exception = NULL)